### PR TITLE
Moved EVP_CIPHER_CTX_set_padding so it has effect

### DIFF
--- a/ManagedOpenSsl/Crypto/Cipher.cs
+++ b/ManagedOpenSsl/Crypto/Cipher.cs
@@ -722,8 +722,8 @@ namespace OpenSSL.Crypto
 					this.ptr, this.cipher.Handle, IntPtr.Zero, real_key, real_iv, enc));
 			}
 
-            if (padding >= 0)
-                Native.ExpectSuccess(Native.EVP_CIPHER_CTX_set_padding(this.ptr, padding));
+			if (padding >= 0)
+				Native.ExpectSuccess(Native.EVP_CIPHER_CTX_set_padding(this.ptr, padding));
 
 			int len = 0;
 			Native.ExpectSuccess(Native.EVP_CipherUpdate(this.ptr, buf, out len, input, input.Length));


### PR DESCRIPTION
Placed EVP_CIPHER_CTX_set_padding after EVP_CipherInit_ex, so the
padding setting doesn't get reset.
