### PR TITLE
fix invalid ASN1 time conversion in case of GeneralizedTime encoding

### DIFF
--- a/ManagedOpenSsl/Core/Asn1DateTime.cs
+++ b/ManagedOpenSsl/Core/Asn1DateTime.cs
@@ -81,11 +81,24 @@ namespace OpenSSL.Core
 		{
 			string str;
 
-			using (var bio = BIO.MemoryBuffer())
+			try
 			{
-				Native.ExpectSuccess(Native.ASN1_UTCTIME_print(bio.Handle, ptr));
-				str = bio.ReadString();
+				using (var bio = BIO.MemoryBuffer())
+				{
+					Native.ExpectSuccess(Native.ASN1_UTCTIME_print(bio.Handle, ptr));
+					str = bio.ReadString();
+				}
 			}
+			catch (Exception)
+			{
+				using (var bio = BIO.MemoryBuffer())
+				{
+					Native.ExpectSuccess(Native.ASN1_GENERALIZEDTIME_print(bio.Handle, ptr));
+					str = bio.ReadString();
+				}
+			}
+
+			
 
 			string[] fmts = 
 			{ 

--- a/ManagedOpenSsl/Core/Native.cs
+++ b/ManagedOpenSsl/Core/Native.cs
@@ -404,6 +404,9 @@ namespace OpenSSL.Core
 		public extern static int ASN1_UTCTIME_print(IntPtr bp, IntPtr a);
 
 		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
+		public extern static int ASN1_GENERALIZEDTIME_print(IntPtr bp, IntPtr a);
+
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
 		public extern static IntPtr ASN1_TIME_new();
 
 		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
happens if you want to set notBefore/ notAfter of a X509Certificate to dates which are far in the future (like 2050)
